### PR TITLE
【template修正PR】/quizの画面をbig_questionが並列して表示されるようにした

### DIFF
--- a/src/resources/views/user/quiz/index.blade.php
+++ b/src/resources/views/user/quiz/index.blade.php
@@ -1,10 +1,8 @@
-@extends('layout.app')
+@extends('layouts.app')
 @section('content')
-    <div class="max-w-2xl mx-auto">
-        <ul>
-            @foreach ($questions as $question)
-                <li><img src="{{ asset('img/' . $question->image) }}" /></li>
+    <div class="flex items-center justify-between mt-5 max-w-2xl mx-auto">
+            @foreach ($big_questions as $big_question)
+                <a class="underline text-lg text-gray-600 hover:text-gray-900" href="quiz/{{ $loop->iteration }}">{{ $big_question->name }}の画面へ</a>
             @endforeach
-        </ul>
     </div>
 @endsection


### PR DESCRIPTION
/quizの画面をbig_questionが並列して表示されるようにした

- イメージ

<img width="1016" alt="image" src="https://user-images.githubusercontent.com/86884063/227511649-1d5a9461-636c-49e1-8081-f2d083e7a71a.png">
